### PR TITLE
Enable gtag tracking

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -77,7 +77,9 @@
         },
       ],
       copyright: `Copyright © ${new Date().getFullYear()} Rythm. Built with Docusaurus.`,
-
+    },
+    gtag: {
+      trackingID: 'G-R24WK20SNS',
     },
   },
   presets: [


### PR DESCRIPTION
Enable gtag tracking via the docusaurus gtag plugin which is pre-bundled with the preset-classic dependency.