### PR TITLE
Fix a small error on Voteskip.md

### DIFF
--- a/docs/Voteskip.md
+++ b/docs/Voteskip.md
@@ -20,7 +20,7 @@ For a vote skip to take effect, `75%` of the people in the voice channel need to
 
 :::caution note
 - Vote skip will not be active until there are **3 or more people** in the voice channel.
-(As with one person, insta-skip is enabled and with two, the threshold for skipping is `75% of 2 = 1.75`, rounded down as 1).
+(As with one person, insta-skip is enabled and with two, the threshold for skipping is `75% of 2 = 1.5`, rounded down as 1).
 - If you have the `DJ` role or `Manage Channels` permission, you can do `!forceskip` or `!fs`, which will instantly skip the song without voting.
 :::
 


### PR DESCRIPTION
0.75*2 = 1.5 ≠ 1.75

This bothered me, so here's a pull request